### PR TITLE
Feature/indite into string

### DIFF
--- a/rosa-test.asd
+++ b/rosa-test.asd
@@ -19,7 +19,8 @@
                 :components
                 ((:file "util")
                  (:test-file "rosa" :depends-on ("util"))
-                 (:test-file "semantics" :depends-on ("util")))))
+                 (:test-file "semantics" :depends-on ("util"))
+                 (:test-file "indite"))))
   :description "Test system for rosa"
 
   :defsystem-depends-on (:prove-asdf)

--- a/rosa.asd
+++ b/rosa.asd
@@ -18,7 +18,8 @@
   :version "0.1"
   :author "Shinichi TANAKA"
   :license "MIT"
-  :depends-on (:anaphora
+  :depends-on (:alexandria
+               :anaphora
                :trivial-gray-streams)
   :components ((:module "src"
                 :components ((:file "rosa"))))

--- a/t/indite.lisp
+++ b/t/indite.lisp
@@ -9,3 +9,19 @@
 (subtest "nil maps to empty string"
   (is (indite '()) "")
   (is (indite (make-hash-table)) ""))
+
+(subtest "mapping of inline label (not has newline)"
+  (is (indite '(:|label| "ghost in the shell"))
+      (format nil ":label ghost in the shell~%"))
+  (let ((hash (make-hash-table)))
+    (setf (gethash :|label|) "ghost in the shell")
+    (is (indite hash)
+        (format nil ":label ghost in the shell~%"))))
+
+(subtest "mapping of block label (has newline)"
+  (is (indite '(:|label| (foramt nil "I hear a voice,~%hear a voice calling out to me~%")))
+      (foramt nil ":label~%I hear a voice,~%hear a voice calling out to me~%"))
+  (let ((hash (make-hash-table)))
+    (setf (gethash :|label|) (foramt nil "I hear a voice,~%hear a voice calling out to me~%"))
+    (is (indite hash)
+        (foramt nil ":label~%I hear a voice,~%hear a voice calling out to me~%"))))

--- a/t/indite.lisp
+++ b/t/indite.lisp
@@ -21,35 +21,35 @@
                (format nil ":label ghost in the shell~%")))
 
 (subtest "mapping of block label (has newline)"
-  (test-indite `(:|label| #(,(format nil "I hear a voice,~%hear a voice calling out to me~%")))
+  (test-indite `(:|label| #(,(format nil "I hear a voice,~%hear a voice calling out to me")))
                (format nil ":label~%I hear a voice,~%hear a voice calling out to me~%")))
 
 (subtest "escape ':' and ';' in block"
   (test-indite `(:|label| #(,(format nil ":I am Calling, calling now~%;Spirit rise and falling")))
-               (format nil ":label~%::I am Calling, calling now~%:;Spirit rise and falling")))
+               (format nil ":label~%::I am Calling, calling now~%:;Spirit rise and falling~%")))
 
 (subtest "multiple data"
   (diag "inline - inline")
   (test-indite `(:|label| #(,(format nil "Save your tears. For the day.")
                             ,(format nil "When our pain is far behind.")))
-               (format nil ":label ~a~%:label ~a"
+               (format nil ":label ~a~%:label ~a~%"
                        "Save your tears. For the day."
                        "our pain is far behind."))
   (diag "block - inline")
   (test-indite `(:|label| #(,(format nil "On your feet.~%Come with me.")
                             ,(format nil "We are soldiers stand or die.")))
-               (format nil ":label~%~a~%:label ~a"
-                       "On your feet.~%Come with me."
+               (format nil ":label~%~a~%~a~%:label ~a~%"
+                       "On your feet." "Come with me."
                        "We are soldiers stand or die."))
   (diag "inline - block")
   (test-indite `(:|label| #(,(format nil "Save your fears.")
                             ,(format nil "Take your place.~%Save them for the judgement day.")))
-               (format nil ":label~%~a~%:label ~a"
+               (format nil ":label ~a~%:label~%~a~%~a~%"
                        "Save your fears."
-                       "Take your place.~%Save them for the judgement day."))
+                       "Take your place." "Save them for the judgement day."))
   (diag "block - block")
   (test-indite `(:|label| #(,(format nil "Fast and free~%Follow me")
                             ,(format nil "Time to make the sacrifice~%We rise or fall ")))
-               (format nil ":label~%~a~%:label~%~a"
-                       "Fast and free~%Follow me"
-                       "Time to make the sacrifice~%We rise or fall ")))
+               (format nil ":label~%~a~%~a~%:label~%~a~%~a~%"
+                       "Fast and free" "Follow me"
+                       "Time to make the sacrifice" "We rise or fall ")))

--- a/t/indite.lisp
+++ b/t/indite.lisp
@@ -21,7 +21,7 @@
                (format nil ":label ghost in the shell~%")))
 
 (subtest "mapping of block label (has newline)"
-  (test-indite `(:|label| #(,(foramt nil "I hear a voice,~%hear a voice calling out to me~%")))
+  (test-indite `(:|label| #(,(format nil "I hear a voice,~%hear a voice calling out to me~%")))
                (foramt nil ":label~%I hear a voice,~%hear a voice calling out to me~%")))
 
 (subtest "escape ':' and ';' in block"

--- a/t/indite.lisp
+++ b/t/indite.lisp
@@ -1,0 +1,11 @@
+(in-package :cl-user)
+(defpackage :rosa-test.indite
+  (:use :cl
+        :rosa
+        :prove))
+(in-package :rosa-test.indite)
+
+
+(subtest "nil maps to empty string"
+  (is (indite '()) "")
+  (is (indite (make-hash-table)) ""))

--- a/t/indite.lisp
+++ b/t/indite.lisp
@@ -11,17 +11,17 @@
   (is (indite (make-hash-table)) ""))
 
 (subtest "mapping of inline label (not has newline)"
-  (is (indite '(:|label| "ghost in the shell"))
+  (is (indite '(:|label| #("ghost in the shell")))
       (format nil ":label ghost in the shell~%"))
   (let ((hash (make-hash-table)))
-    (setf (gethash :|label|) "ghost in the shell")
+    (setf (gethash :|label|) #("ghost in the shell"))
     (is (indite hash)
         (format nil ":label ghost in the shell~%"))))
 
 (subtest "mapping of block label (has newline)"
-  (is (indite '(:|label| (foramt nil "I hear a voice,~%hear a voice calling out to me~%")))
+  (is (indite `(:|label| #(,(foramt nil "I hear a voice,~%hear a voice calling out to me~%"))))
       (foramt nil ":label~%I hear a voice,~%hear a voice calling out to me~%"))
   (let ((hash (make-hash-table)))
-    (setf (gethash :|label|) (foramt nil "I hear a voice,~%hear a voice calling out to me~%"))
+    (setf (gethash :|label|) #((foramt nil "I hear a voice,~%hear a voice calling out to me~%")))
     (is (indite hash)
         (foramt nil ":label~%I hear a voice,~%hear a voice calling out to me~%"))))

--- a/t/indite.lisp
+++ b/t/indite.lisp
@@ -8,6 +8,8 @@
 (in-package :rosa-test.indite)
 
 
+(plan 5)
+
 (defun test-indite (actual-plist expected-string)
   (is (indite actual-plist) expected-string)
   (let ((actual-hash (plist-hash-table actual-plist)))
@@ -53,3 +55,5 @@
                (format nil ":label~%~a~%~a~%:label~%~a~%~a~%"
                        "Fast and free" "Follow me"
                        "Time to make the sacrifice" "We rise or fall ")))
+
+(finalize)

--- a/t/indite.lisp
+++ b/t/indite.lisp
@@ -29,21 +29,25 @@
                (format nil ":label~%::I am Calling, calling now~%:;Spirit rise and falling")))
 
 (subtest "multiple data"
+  (diag "inline - inline")
   (test-indite `(:|label| #(,(format nil "Save your tears. For the day.")
                             ,(format nil "When our pain is far behind.")))
                (format nil ":label ~a~%:label ~a"
                        "Save your tears. For the day."
                        "our pain is far behind."))
+  (diag "block - inline")
   (test-indite `(:|label| #(,(format nil "On your feet.~%Come with me.")
                             ,(format nil "We are soldiers stand or die.")))
                (format nil ":label~%~a~%:label ~a"
                        "On your feet.~%Come with me."
                        "We are soldiers stand or die."))
+  (diag "inline - block")
   (test-indite `(:|label| #(,(format nil "Save your fears.")
                             ,(format nil "Take your place.~%Save them for the judgement day.")))
                (format nil ":label~%~a~%:label ~a"
                        "Save your fears."
                        "Take your place.~%Save them for the judgement day."))
+  (diag "block - block")
   (test-indite `(:|label| #(,(format nil "Fast and free~%Follow me")
                             ,(format nil "Time to make the sacrifice~%We rise or fall ")))
                (format nil ":label~%~a~%:label~%~a"

--- a/t/indite.lisp
+++ b/t/indite.lisp
@@ -34,7 +34,7 @@
                             ,(format nil "When our pain is far behind.")))
                (format nil ":label ~a~%:label ~a~%"
                        "Save your tears. For the day."
-                       "our pain is far behind."))
+                       "When our pain is far behind."))
   (diag "block - inline")
   (test-indite `(:|label| #(,(format nil "On your feet.~%Come with me.")
                             ,(format nil "We are soldiers stand or die.")))

--- a/t/indite.lisp
+++ b/t/indite.lisp
@@ -22,7 +22,7 @@
 
 (subtest "mapping of block label (has newline)"
   (test-indite `(:|label| #(,(format nil "I hear a voice,~%hear a voice calling out to me~%")))
-               (foramt nil ":label~%I hear a voice,~%hear a voice calling out to me~%")))
+               (format nil ":label~%I hear a voice,~%hear a voice calling out to me~%")))
 
 (subtest "escape ':' and ';' in block"
   (test-indite `(:|label| #(,(format nil ":I am Calling, calling now~%;Spirit rise and falling")))

--- a/t/indite.lisp
+++ b/t/indite.lisp
@@ -2,56 +2,50 @@
 (defpackage :rosa-test.indite
   (:use :cl
         :rosa
-        :prove))
+        :prove)
+  (:import-from :alexandria
+                :plist-hash-table))
 (in-package :rosa-test.indite)
 
 
+(defun test-indite (actual-plist expected-string)
+  (is (indite actual-plist) expected-string)
+  (let ((actual-hash (plist-hash-table actual-plist)))
+    (is (indite actual-hash) expected-string)))
+
 (subtest "nil maps to empty string"
-  (is (indite '()) "")
-  (is (indite (make-hash-table)) ""))
+  (test-indite '() ""))
 
 (subtest "mapping of inline label (not has newline)"
-  (is (indite '(:|label| #("ghost in the shell")))
-      (format nil ":label ghost in the shell~%"))
-  (let ((hash (make-hash-table)))
-    (setf (gethash :|label|) #("ghost in the shell"))
-    (is (indite hash)
-        (format nil ":label ghost in the shell~%"))))
+  (test-indite '(:|label| #("ghost in the shell"))
+               (format nil ":label ghost in the shell~%")))
 
 (subtest "mapping of block label (has newline)"
-  (is (indite `(:|label| #(,(foramt nil "I hear a voice,~%hear a voice calling out to me~%"))))
-      (foramt nil ":label~%I hear a voice,~%hear a voice calling out to me~%"))
-  (let ((hash (make-hash-table)))
-    (setf (gethash :|label|) #((foramt nil "I hear a voice,~%hear a voice calling out to me~%")))
-    (is (indite hash)
-        (foramt nil ":label~%I hear a voice,~%hear a voice calling out to me~%"))))
+  (test-indite `(:|label| #(,(foramt nil "I hear a voice,~%hear a voice calling out to me~%")))
+               (foramt nil ":label~%I hear a voice,~%hear a voice calling out to me~%")))
 
 (subtest "escape ':' and ';' in block"
-  (is (indite `(:|label| #(,(format nil ":I am Calling, calling now~%;Spirit rise and falling"))))
-      (format nil ":label~%::I am Calling, calling now~%:;Spirit rise and falling"))
-  (let ((hash (make-hash-table)))
-    (setf (gethash :|label|) #((format nil ":I am Calling, calling now~%;Spirit rise and falling")))
-    (is (indite hash)
-        (format nil ":label~%::I am Calling, calling now~%:;Spirit rise and falling"))))
+  (test-indite `(:|label| #(,(format nil ":I am Calling, calling now~%;Spirit rise and falling")))
+               (format nil ":label~%::I am Calling, calling now~%:;Spirit rise and falling")))
 
 (subtest "multiple data"
-  (is (indite `(:|label| #(,(format nil "Save your tears. For the day.")
-                           ,(format nil "When our pain is far behind.")))
-              (format nil ":label ~a~%:label ~a"
-                      "Save your tears. For the day."
-                      "our pain is far behind.")))
-  (is (indite `(:|label| #(,(format nil "On your feet.~%Come with me.")
-                           ,(format nil "We are soldiers stand or die.")))
-              (format nil ":label~%~a~%:label ~a"
-                      "On your feet.~%Come with me."
-                      "We are soldiers stand or die.")))
-  (is (indite `(:|label| #(,(format nil "Save your fears.")
-                           ,(format nil "Take your place.~%Save them for the judgement day.")))
-              (format nil ":label~%~a~%:label ~a"
-                      "Save your fears."
-                      "Take your place.~%Save them for the judgement day.")))
-  (is (indite `(:|label| #(,(format nil "Fast and free~%Follow me")
-                           ,(format nil "Time to make the sacrifice~%We rise or fall ")))
-              (format nil ":label~%~a~%:label~%~a"
-                      "Fast and free~%Follow me"
-                      "Time to make the sacrifice~%We rise or fall "))))
+  (test-indite `(:|label| #(,(format nil "Save your tears. For the day.")
+                            ,(format nil "When our pain is far behind.")))
+               (format nil ":label ~a~%:label ~a"
+                       "Save your tears. For the day."
+                       "our pain is far behind."))
+  (test-indite `(:|label| #(,(format nil "On your feet.~%Come with me.")
+                            ,(format nil "We are soldiers stand or die.")))
+               (format nil ":label~%~a~%:label ~a"
+                       "On your feet.~%Come with me."
+                       "We are soldiers stand or die."))
+  (test-indite `(:|label| #(,(format nil "Save your fears.")
+                            ,(format nil "Take your place.~%Save them for the judgement day.")))
+               (format nil ":label~%~a~%:label ~a"
+                       "Save your fears."
+                       "Take your place.~%Save them for the judgement day."))
+  (test-indite `(:|label| #(,(format nil "Fast and free~%Follow me")
+                            ,(format nil "Time to make the sacrifice~%We rise or fall ")))
+               (format nil ":label~%~a~%:label~%~a"
+                       "Fast and free~%Follow me"
+                       "Time to make the sacrifice~%We rise or fall ")))

--- a/t/indite.lisp
+++ b/t/indite.lisp
@@ -25,3 +25,11 @@
     (setf (gethash :|label|) #((foramt nil "I hear a voice,~%hear a voice calling out to me~%")))
     (is (indite hash)
         (foramt nil ":label~%I hear a voice,~%hear a voice calling out to me~%"))))
+
+(subtest "escape ':' and ';' in block"
+  (is (indite `(:|label| #(,(format nil ":I am Calling, calling now~%;Spirit rise and falling"))))
+      (format nil ":label~%::I am Calling, calling now~%:;Spirit rise and falling"))
+  (let ((hash (make-hash-table)))
+    (setf (gethash :|label|) #((format nil ":I am Calling, calling now~%;Spirit rise and falling")))
+    (is (indite hash)
+        (format nil ":label~%::I am Calling, calling now~%:;Spirit rise and falling"))))

--- a/t/indite.lisp
+++ b/t/indite.lisp
@@ -33,3 +33,25 @@
     (setf (gethash :|label|) #((format nil ":I am Calling, calling now~%;Spirit rise and falling")))
     (is (indite hash)
         (format nil ":label~%::I am Calling, calling now~%:;Spirit rise and falling"))))
+
+(subtest "multiple data"
+  (is (indite `(:|label| #(,(format nil "Save your tears. For the day.")
+                           ,(format nil "When our pain is far behind.")))
+              (format nil ":label ~a~%:label ~a"
+                      "Save your tears. For the day."
+                      "our pain is far behind.")))
+  (is (indite `(:|label| #(,(format nil "On your feet.~%Come with me.")
+                           ,(format nil "We are soldiers stand or die.")))
+              (format nil ":label~%~a~%:label ~a"
+                      "On your feet.~%Come with me."
+                      "We are soldiers stand or die.")))
+  (is (indite `(:|label| #(,(format nil "Save your fears.")
+                           ,(format nil "Take your place.~%Save them for the judgement day.")))
+              (format nil ":label~%~a~%:label ~a"
+                      "Save your fears."
+                      "Take your place.~%Save them for the judgement day.")))
+  (is (indite `(:|label| #(,(format nil "Fast and free~%Follow me")
+                           ,(format nil "Time to make the sacrifice~%We rise or fall ")))
+              (format nil ":label~%~a~%:label~%~a"
+                      "Fast and free~%Follow me"
+                      "Time to make the sacrifice~%We rise or fall "))))

--- a/t/rosa.lisp
+++ b/t/rosa.lisp
@@ -120,5 +120,11 @@ We can consider **Label** as *key* and **body** as *value*.
   (let ((data (peruse in)))
     (is (peruse (indite data)) data)))
 
+;;; indite can takes plist
+(with-input-from-string (in *test-string*)
+  (let ((data (peruse-as-plist in))
+        (expected (peruse in)))
+    (is (peruse (indite data)) expected)))
+
 
 (finalize)

--- a/t/rosa.lisp
+++ b/t/rosa.lisp
@@ -118,13 +118,17 @@ We can consider **Label** as *key* and **body** as *value*.
 ;;; rosa write data into a string
 (with-input-from-string (in *test-string*)
   (let ((data (peruse in)))
-    (is (peruse (indite data)) data)))
+    (with-input-from-string (in (indite data))
+      (is (peruse in) data))))
 
 ;;; indite can takes plist
-(with-input-from-string (in *test-string*)
-  (let ((data (peruse-as-plist in))
-        (expected (peruse in)))
-    (is (peruse (indite data)) expected)))
+
+(let ((plist-data (with-input-from-string (in *test-string*)
+                    (peruse-as-plist in)))
+      (expected (with-input-from-string (in *test-string*)
+                  (peruse in))))
+  (with-input-from-string (in (indite plist-data))
+    (is (peruse in) expected)))
 
 
 (finalize)

--- a/t/rosa.lisp
+++ b/t/rosa.lisp
@@ -118,7 +118,7 @@ We can consider **Label** as *key* and **body** as *value*.
 ;;; rosa write data into a string
 (with-input-from-string (in *test-string*)
   (let ((data (peruse in)))
-    (is data (peruse (indite data)))))
+    (is (peruse (indite data)) data)))
 
 
 (finalize)

--- a/t/rosa.lisp
+++ b/t/rosa.lisp
@@ -119,7 +119,7 @@ We can consider **Label** as *key* and **body** as *value*.
 (with-input-from-string (in *test-string*)
   (let ((data (peruse in)))
     (with-input-from-string (in (indite data))
-      (is (peruse in) data))))
+      (is (peruse in) data :test #'equalp))))
 
 ;;; indite can takes plist
 
@@ -128,7 +128,7 @@ We can consider **Label** as *key* and **body** as *value*.
       (expected (with-input-from-string (in *test-string*)
                   (peruse in))))
   (with-input-from-string (in (indite plist-data))
-    (is (peruse in) expected)))
+    (is (peruse in) expected :test #'equalp)))
 
 
 (finalize)

--- a/t/rosa.lisp
+++ b/t/rosa.lisp
@@ -115,5 +115,10 @@ We can consider **Label** as *key* and **body** as *value*.
     #("Rosa - text labeling language")
     :test #'equalp)
 
+;;; rosa write data into a string
+(with-input-from-string (in *test-string*)
+  (let ((data (peruse in)))
+    (is data (peruse (indite data)))))
+
 
 (finalize)


### PR DESCRIPTION
For my personal interest, I tried to implement `inditing`: writing key-value data into string.

I have no idea what this feature is used, but `indite` brings adjoint-like thing to rosa. Any strings are mapped to key-value data, and key-value datum are mapped to rosa-language string. In other word, `peruse` brings element of string world to key-value world and `indite` brings element of key-value world to rosa-language world.

But this fact has no meanings to use, I think.