### PR TITLE
14 label identifier syntax

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,7 +22,7 @@ Here, a pair in rosa data structure, it consist of just one **label** and multip
 Because of it, array of **bodies** is simply called **body**.
 
 **Label** is a meta data of **body**.
-It is a string represented as regex `[a-z][a-z0-9-]*`.
+It is a string represented as regex `[a-zA-Z][a-zA-Z0-9-_]*`.
 
 **Body** is a value of **label**.
 It is a array of strings.

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -7,7 +7,7 @@
 <SEMICOLON> ::= ? semicolon (`;`) ?
 <EOF> ::= ? end-of-file ?
 <EOL> ::= ? end-of-line (e.g. LF) ?
-<LABEL_IDENTIFER> ::= ? represented as regex `[a-z0-9][a-z0-9-]*` ?
+<LABEL_IDENTIFER> ::= ? represented as regex `[a-zA-Z0-9][A-Za-z0-9-_]*` ?
 <NOT_DELIMITER> ::= ? represent as regex `[^;:]` ?
 <ANYCHAR> ::= ? any charactor excluding <EOF> and <EOL> ?
 

--- a/src/rosa.lisp
+++ b/src/rosa.lisp
@@ -25,17 +25,20 @@
      ,@body))
 
 (defun label-p (text)
-  "label identifier is defined by regex \"[a-z][a-z0-9-]*\""
+  "label identifier is defined by regex \"[a-zA-Z][a-zA-Z0-9-_]*\""
   ;; but this impl depends on ASCII-like char-code...
   (labels ((identifier-first-char-p (ch)
              (let ((ch-code (char-code ch)))
-               (and (<= (char-code #\a) ch-code)
-                    (>= (char-code #\z) ch-code))))
+               (or (and (<= (char-code #\a) ch-code)
+                        (>= (char-code #\z) ch-code))
+                   (and (<= (char-code #\A) ch-code)
+                        (>= (char-code #\Z) ch-code)))))
            (identifier-char-p (ch)
              (let ((ch-code (char-code ch)))
                (or (identifier-first-char-p ch)
                    (and (<= (char-code #\0) ch-code)
                         (>= (char-code #\9) ch-code))
+                   (char= ch #\_)
                    (char= ch #\-)))))
     (loop
        :for ch :across text

--- a/t/semantics.lisp
+++ b/t/semantics.lisp
@@ -25,20 +25,23 @@
 (subtest "inline labels"
   (diag "inline label is consists of two parts; label string and body string")
 
-  (subtest "inline label is represent as regexp `^:([a-z0-9][a-z0-9-]*) (.+)$`"
+  (subtest "inline label is represent as regexp `^:([a-zA-Z0-9][a-zA-Z0-9-_]*) (.+)$`"
     (perusing-test ":abcd is read as label"
                    '(:|abcd| #("is read as label")))
+    (perusing-test ":abCD is read as label"
+                   '(:|abCD| #("is read as label")))
+    (perusing-test ":ABCD is read as label"
+                   '(:ABCD #("is read as label")))
     (perusing-test ":abcd-efg is read as label"
                    '(:|abcd-efg| #("is read as label")))
     (perusing-test ":abcd- is read as label"
-                   '(:|abcd-| #("is read as label"))))
+                   '(:|abcd-| #("is read as label")))
+    (perusing-test ":abcd_ is read as label"
+                   '(:|abcd_| #("is read as label"))))
 
   (subtest "these are not inline labels"
     (perusing-test ":-abcd is not read as label" nil)
-    (perusing-test ":ABCD is not read as label" nil)
-    (perusing-test ":abCD is not read as label" nil)
-    (perusing-test ":abcd_ is not read as label" nil)
-    (perusing-test ":abCD is not read as label" nil))
+    (perusing-test ":_abcd is not read as label" nil))
 
   (subtest "body can include any characters except line-break"
     (perusing-test ":label body" '(:|label| #("body")))
@@ -58,26 +61,29 @@
 (subtest "block labels"
   (diag "block label is consists of two parts; label line and following body line(s)")
 
-  (subtest "block label is represent as regexp `^:([a-z0-9][a-z0-9-]*)$`"
+  (subtest "block label is represent as regexp `^:([a-zA-Z0-9][a-zA-Z0-9-_]*)$`"
     (diag "single appearance of label line")
     (perusing-test (format nil ":abcd") '(:|abcd| #("")))
     (perusing-test (format nil ":abcd-efg") '(:|abcd-efg| #("")))
     (perusing-test (format nil ":abcd-") '(:|abcd-| #(""))))
 
-  (subtest "block label is represent as regexp `^:([a-z0-9][a-z0-9-]*)$`"
+  (subtest "block label is represent as regexp `^:([a-zA-Z0-9][a-zA-Z0-9-_]*)$`"
     (perusing-test (format nil ":abcd~%is read as label")
                    '(:|abcd| #("is read as label")))
+    (perusing-test (format nil ":abCD~%is read as label")
+                   '(:|abCD| #("is read as label")))
+    (perusing-test (format nil ":ABCD~%is read as label")
+                   '(:ABCD #("is read as label")))
     (perusing-test (format nil ":abcd-efg~%is read as label")
                    '(:|abcd-efg| #("is read as label")))
     (perusing-test (format nil ":abcd-~%is read as label")
-                   '(:|abcd-| #("is read as label"))))
+                   '(:|abcd-| #("is read as label")))
+    (perusing-test (format nil ":abcd_~%is read as label")
+                   '(:|abcd_| #("is read as label"))))
 
   (subtest "these are not label"
     (perusing-test (format nil ":-abcd~%is not read as label") nil)
-    (perusing-test (format nil ":ABCD~%is not read as label") nil)
-    (perusing-test (format nil ":abCD~%is not read as label") nil)
-    (perusing-test (format nil ":abcd_~%is not read as label") nil)
-    (perusing-test (format nil ":abCD~%is not read as label") nil))
+    (perusing-test (format nil ":_abcd~%is not read as label") nil))
 
   (subtest "body can include any lines except both kind of labels"
     (perusing-test (format nil ":label~%body") '(:|label| #("body")))


### PR DESCRIPTION
Now we can use **capital cases** and **underscore** !