### PR TITLE
List shorthand notation

### DIFF
--- a/tests/semantics.lisp
+++ b/tests/semantics.lisp
@@ -71,10 +71,8 @@
     (perusing-test (format nil ":label>") nil)
 
     (subtest "lines starts with only '- ' are regarded as `list`"
-      (perusing-test (format nil ":label>~%-spaaaaaaaace")
-                     '(:|label| #("")))
-      (perusing-test (format nil ":label>~% - spaaaaaaaace")
-                     '(:|label| #("")))))
+      (perusing-test (format nil ":label>~%-spaaaaaaaace") nil)
+      (perusing-test (format nil ":label>~% - spaaaaaaaace") nil)))
 
   (subtest "empty lines are ignored"
     (perusing-test (format nil ":label>~%- spaaaaaaaace~%")

--- a/tests/semantics.lisp
+++ b/tests/semantics.lisp
@@ -6,7 +6,7 @@
         :prove))
 (in-package :rosa/tests/semantics)
 
-(plan 8)
+(plan 9)
 
 
 (defun perusing-test (actual expected)
@@ -57,6 +57,32 @@
       (perusing-test (format nil ":label so long~%:label2~%and thanks for all the fish")
                      '(:|label| #("so long")
                        :|label2| #("and thanks for all the fish"))))))
+
+(subtest "list notation for multiple inline label"
+  (perusing-test (format nil ":label>~%- spaaaaaaaace")
+                 '(:|label| #("spaaaaaaaace")))
+  (perusing-test (format nil ":label>~%- spaaaaaaaace~%- in space")
+                 '(:|label| #("spaaaaaaaace" "in space")))
+  (perusing-test (format nil ":label>~%- spaaaaaaaace~%- in space~%")
+                 '(:|label| #("spaaaaaaaace" "in space")))
+
+  (subtest "empty list is nil"
+    (perusing-test (format nil ":label>~%") nil)
+    (perusing-test (format nil ":label>") nil)
+
+    (subtest "lines starts with only '- ' are regarded as `list`"
+      (perusing-test (format nil ":label>~%-spaaaaaaaace")
+                     '(:|label| #("")))
+      (perusing-test (format nil ":label>~% - spaaaaaaaace")
+                     '(:|label| #("")))))
+
+  (subtest "empty lines are ignored"
+    (perusing-test (format nil ":label>~%- spaaaaaaaace~%")
+                   '(:|label| #("spaaaaaaaace")))
+    (perusing-test (format nil ":label>~%- spaaaaaaaace~%~%")
+                   '(:|label| #("spaaaaaaaace")))
+    (perusing-test (format nil ":label>~%- spaaaaaaaace~%~%- in space")
+                   '(:|label| #("spaaaaaaaace" "in space")))))
 
 (subtest "block labels"
   (diag "block label is consists of two parts; label line and following body line(s)")


### PR DESCRIPTION
This PR adds list shorthand notation proposed on issue https://github.com/t-sin/rosa/issues/18. The notation makes us easy to multiple value for one label.

This list

```lisp
CL-USER> (with-input-from-string (in ":tag programming
:tag lisp
:tag common-lisp
")
           (rosa:peruse-as-plist in))
(:|tag| #("programming" "lisp" "common-lisp"))
```

with list notation turns into like this:

```lisp
CL-USER> (with-input-from-string (in ":tag>
- programming
- lisp
- common-lisp")
           (rosa:peruse-as-plist in))
(:|tag| #("programming" "lisp" "common-lisp"))
```